### PR TITLE
allow negative rates

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,5 @@
 name: CI Jobs
-on: [push]
+on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/shared/getSettings.ts
+++ b/shared/getSettings.ts
@@ -5,8 +5,8 @@ interface Settings {
 }
 
 export default function(g: Goal): Settings {
-  const minMatches = g.fineprint?.match(/#autodialMin=((?:[\d.]+)?\d)/);
-  const maxMatches = g.fineprint?.match(/#autodialMax=((?:[\d.]+)?\d)/);
+  const minMatches = g.fineprint?.match(/#autodialMin=(-?\d*\.?\d+)/);
+  const maxMatches = g.fineprint?.match(/#autodialMax=(-?\d*\.?\d+)/);
   const min = minMatches ? parseFloat(minMatches[1]) : -Infinity;
   const max = maxMatches ? parseFloat(maxMatches[1]) : Infinity;
 


### PR DESCRIPTION
The original regexes also allowed strings such as "1.2.2" and "...3".
I've simplified it and also allowed negative numbers (prefixed with "-")
to be matched. This regex was tested at https://regex101.com/r/WMsCS5/1.

I haven't setup a dev environment for this tool, so I don't know if the rest of the app is equipped for negative rates.