### PR TITLE
Fix strict mode

### DIFF
--- a/src/lib/dial.ts
+++ b/src/lib/dial.ts
@@ -15,8 +15,8 @@ export function dial(
 ): Roadall | false {
   const t = now();
   const {min = -Infinity, max = Infinity, strict = false} = opts;
-  const strictMin = strict && g.rate !== null ? Math.max(min, g.rate) : min;
-  const strictMax = strict && g.rate !== null ? Math.min(max, g.rate) : max;
+  const strictMin = strict && g.rate !== null && g.yaw == 1 ? Math.max(min, g.rate) : min;
+  const strictMax = strict && g.rate !== null && g.yaw == -1 ? Math.min(max, g.rate) : max;
   const rateSeconds = UNIT_SECONDS[g.runits];
   const averagePerSecond = getRollingAverageRate(g);
   const len = t - g.fullroad[0][0];


### PR DESCRIPTION
Currently, strict mode forces the autodialler to treat the current rate as _both_ the maximum and minimum.
To fix this, I've made it take the yaw into account, so that Do More goals only have a strict minimum and Do Less goals only a strict maximum.
Should also work for goals with negative rates.