### PR TITLE
Enable autodialAdd

### DIFF
--- a/src/component/molecule/goalRow.tsx
+++ b/src/component/molecule/goalRow.tsx
@@ -94,7 +94,9 @@ export default function GoalRow(
         </>}
       </Box>
     </TableCell>
-    <TableCell>{arpn !== undefined && `${fn(arpn)}/${goal.runits}`}</TableCell>
+    <TableCell>{arpn !== undefined && 
+    `${fn(arpn)}${settings?.add == 0 ? "" : "+" + settings?.add}/${goal.runits}`
+    }</TableCell>
     <TableCell>{goal.weekends_off ? "yes" : "no"}</TableCell>
     <TableCell>{moment.duration(getGoalAge(goal) * 1000).humanize()}</TableCell>
   </TableRow>;

--- a/src/component/molecule/goalRow.tsx
+++ b/src/component/molecule/goalRow.tsx
@@ -44,7 +44,7 @@ export default function GoalRow(
   const [arpn, setArpn] = useState<number>();
   const [edge, setEdge] = useState<number>(0);
 
-  const success = edge === goal.yaw;
+  const success = edge === 1;
   const backgroundColor = success ? green[50] : "initial";
 
   useEffect(() => {

--- a/src/component/molecule/goalRow.tsx
+++ b/src/component/molecule/goalRow.tsx
@@ -94,7 +94,7 @@ export default function GoalRow(
         </>}
       </Box>
     </TableCell>
-    <TableCell>{arpn !== undefined && 
+    <TableCell>{arpn !== undefined &&
     `${fn(arpn)}${settings?.add == 0 ? "" : "+" + settings?.add}/${goal.runits}`
     }</TableCell>
     <TableCell>{goal.weekends_off ? "yes" : "no"}</TableCell>

--- a/src/component/organism/stepTwo.tsx
+++ b/src/component/organism/stepTwo.tsx
@@ -13,7 +13,7 @@ export default function StepTwo(): JSX.Element {
 
   return <>
     <h3>Step 2: Configure specific goals to use the autodialer</h3>
-    <p>Add one or more of the following three tags to the fineprint of the goals
+    <p>Add one or more of the following four tags to the fineprint of the goals
       you wish to autodial:</p>
 
     <Tags />

--- a/src/component/organism/stepTwo.tsx
+++ b/src/component/organism/stepTwo.tsx
@@ -13,7 +13,7 @@ export default function StepTwo(): JSX.Element {
 
   return <>
     <h3>Step 2: Configure specific goals to use the autodialer</h3>
-    <p>Add one or more of the following four tags to the fineprint of the goals
+    <p>Add one or more of the following tags to the fineprint of the goals
       you wish to autodial:</p>
 
     <Tags />

--- a/src/component/organism/tags.tsx
+++ b/src/component/organism/tags.tsx
@@ -39,6 +39,11 @@ export default function Tags(): JSX.Element {
           <TableCell>Enables autodialing and prevents autodialer from ever
             making goal easier.</TableCell>
         </TableRow>
+        <TableRow>
+          <TableCell>#autodialAdd=1</TableCell>
+          <TableCell>Enables autodialing and specifies an amount to be added
+            to your 30-day average (can be negative).</TableCell>
+        </TableRow>
       </TableBody>
     </Table>
   </TableContainer>;

--- a/src/lib/dial.ts
+++ b/src/lib/dial.ts
@@ -18,7 +18,7 @@ export function dial(
   if (lastRow[2] === null) return false;
 
   const t = now();
-  const {min = -Infinity, max = Infinity, strict = false} = opts;
+  const {min = -Infinity, max = Infinity, strict = false, add = 0} = opts;
   const neverLess = strict && g.yaw == 1;
   const neverMore = strict && g.yaw == -1;
   const strictMin = neverLess && g.rate !== null ? Math.max(min, g.rate) : min;
@@ -27,7 +27,7 @@ export function dial(
   const averagePerSecond = getRollingAverageRate(g);
   const len = t - g.fullroad[0][0];
   const oldRate = g.mathishard[2];
-  const newRate = averagePerSecond * rateSeconds;
+  const newRate = averagePerSecond * rateSeconds + add;
   const monthCompletion = Math.min(len / (SID * 30), 1);
   const rateDiff = oldRate - newRate;
   const modulatedRate = oldRate - (rateDiff * monthCompletion);

--- a/src/lib/getSettings.ts
+++ b/src/lib/getSettings.ts
@@ -5,19 +5,23 @@ export type AutodialSettings = {
   min: number,
   max: number,
   strict: boolean,
+  add: number,
 }
 
 export function getSettings(g: Goal): AutodialSettings {
   const text = `${g.fineprint} ${g.title}`;
   const minMatches = text.match(/#autodialMin=(-?\d*\.?\d+)/);
   const maxMatches = text.match(/#autodialMax=(-?\d*\.?\d+)/);
+  const addMatches = text.match(/#autodialAdd=(-?\d*\.?\d+)/);
   const min = minMatches ? parseFloat(minMatches[1]) : -Infinity;
   const max = maxMatches ? parseFloat(maxMatches[1]) : Infinity;
+  const add = addMatches ? parseFloat(addMatches[1]) : 0;
 
   return {
     autodial: text.includes("#autodial") || false,
     min,
     max,
     strict: text.includes("#autodialStrict") || false,
+    add,
   };
 }


### PR DESCRIPTION
Allows a constant amount to be added to the 30-day average rate (as discussed on the Beeminder forum).
Also includes a bug fix that fixes the background colour for goals with negative yaw, so that they're green when they reach the minimum rate instead of the maximum.